### PR TITLE
fix: fix repeated trigger errir when deploy cleaner trigger twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fc-proxied-invoke",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "This is a component demo for Serverless Devs Tool ",
   "autoInstall": false,
   "keywords": [

--- a/publish.yaml
+++ b/publish.yaml
@@ -2,7 +2,7 @@ Type: Component
 Name: fc-proxied-invoke
 Provider:
   - 其它
-Version: 0.0.11
+Version: 0.0.12
 Description: 初始化component模板
 HomePage: https://www.serverless-devs.com
 Tags: #标签详情

--- a/src/lib/helper/deploy.ts
+++ b/src/lib/helper/deploy.ts
@@ -47,8 +47,13 @@ export async function deployCleaner(client: any, credentials: ICredentials) {
           logger.debug(`Cleaner function already exist online.`);
         }
       }
-
-      await client.createTrigger(serviceConfig.name, functionConfig.name, triggerConfig);
+      try {
+        await client.createTrigger(serviceConfig.name, functionConfig.name, triggerConfig);
+      } catch (e) {
+        if (e.name === 'FCTriggerAlreadyExistsError') {
+          logger.debug(`Cleaner trigger already exist online.`);
+        }
+      }
       await client.invokeFunction(serviceConfig.name, functionConfig.name, null);
     } catch (err) {
       logger.error(err);


### PR DESCRIPTION
### Fix

1. 重复部署 cleaner 函数的定时触发器时，会报重复部署触发器的错误